### PR TITLE
Added 'index.html' to Lighttpd index file name configuration for webs…

### DIFF
--- a/fluxion
+++ b/fluxion
@@ -4505,7 +4505,7 @@ range $RANG_IP.100 $RANG_IP.250;
   server.error-handler-404 = \"/\"
 
   static-file.exclude-extensions = ( \".fcgi\", \".php\", \".rb\", \"~\", \".inc\" )
-  index-file.names = ( \"index.htm\" )
+  index-file.names = ( \"index.htm\", \"index.html\" )
 
   \$SERVER[\"socket\"] == \":443\" {
   	url.redirect = ( \"^/(.*)\" => \"http://www.internet.com\")


### PR DESCRIPTION
…ite templates that use .html instead of .htm

Some templates (I tried to use the KPN_NL template) use index.html for the index. This was not correctly reflected in the Lighttpd config resulting in the target device (in my testing an android device) not receiving a "Sign in to WiFi network" notification but showing a "Wi-Fi has no internet access" notification instead. the /index.html was manually reachable but / returned a 403 error. This addition to the index-file.names should correct this issue.